### PR TITLE
Bugfix

### DIFF
--- a/python_chess_engine.ipynb
+++ b/python_chess_engine.ipynb
@@ -243,7 +243,7 @@
         "    \n",
         "    best_moves = list(dict_.keys())\n",
         " \n",
-        "    return best_moves[0:int(len(best_moves)*proportion)]"
+        "    return best_moves[0:int(np.ceil(len(best_moves)*proportion))]"
       ],
       "execution_count": 4,
       "outputs": []


### PR DESCRIPTION
Previously would crash if there was only one legal move, since it was only searching through 1 x 0.5 rounds down to 0 top moves.